### PR TITLE
Use keyToVerificationMethod

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Here are some of the parameters used to generate a presentation:
   - `holder` is set to the selected credential's `didKey`;
   - `verifiableCredential` is set to the credential value;
 - `options`
-  - `verificationMethod` is set to the `didKey`;
+  - `verificationMethod` is set to the DID's `verificationMethod` `id`;
   - `proofPurpose` is set to `'authentication'`;
   - `challenge` is set to the request's `challenge';
   - `domain` is set to the request's `domain';

--- a/lib/app/pages/credentials/blocs/scan.dart
+++ b/lib/app/pages/credentials/blocs/scan.dart
@@ -124,6 +124,7 @@ class ScanBloc extends Bloc<ScanEvent, ScanState> {
       final storage = FlutterSecureStorage();
       final key = await storage.read(key: keyId);
       final didKey = await DIDKit.keyToDIDKey(key);
+      final verificationMethod = await DIDKit.keyToVerificationMethod(key);
 
       final credential = await client.post(
         url,
@@ -137,7 +138,7 @@ class ScanBloc extends Bloc<ScanEvent, ScanState> {
       final verification = await DIDKit.verifyCredential(
         jsonEncode(jsonCredential),
         jsonEncode({
-          'verificationMethod': didKey,
+          'verificationMethod': verificationMethod,
           'proofPurpose': 'assertionMethod',
         }),
       );
@@ -203,6 +204,7 @@ class ScanBloc extends Bloc<ScanEvent, ScanState> {
       final storage = FlutterSecureStorage();
       final key = await storage.read(key: keyId);
       final didKey = await DIDKit.keyToDIDKey(key);
+      final verificationMethod = await DIDKit.keyToVerificationMethod(key);
 
       final repository = Modular.get<CredentialsRepository>();
       final credentials = await repository.rawFindAll();
@@ -217,7 +219,7 @@ class ScanBloc extends Bloc<ScanEvent, ScanState> {
             'verifiableCredential': credentials.first,
           }),
           jsonEncode({
-            'verificationMethod': didKey,
+            'verificationMethod': verificationMethod,
             'proofPurpose': 'authentication',
             'challenge': event.challenge,
             'domain': event.domain,


### PR DESCRIPTION
This updates proof options to set `verificationMethod` using the DIDKit `keyToVerificationMethod` function proposed in https://github.com/spruceid/didkit/pull/13 (https://github.com/spruceid/ssi/pull/42). This uses the a DID URL (`did:key:<hash>#<hash>`) instead of just the DID (`did:key:<hash>`), for better interoperability.