### PR TITLE
Enable DID-Tezos by Default Instead of DID-Key

### DIFF
--- a/lib/app/shared/constants.dart
+++ b/lib/app/shared/constants.dart
@@ -1,3 +1,3 @@
 class Constants {
-  static final String defaultDIDMethod = 'key';
+  static final String defaultDIDMethod = 'tz';
 }


### PR DESCRIPTION
This PR changes did-tezos to be the default did-method for Credible.

Signed-off-by: Tiago Nascimento <tiago.nascimento@spruceid.com>